### PR TITLE
refactor: remove `assert` dependency and replace with custom utility

### DIFF
--- a/dev/lib/defTermFlowToken.ts
+++ b/dev/lib/defTermFlowToken.ts
@@ -3,8 +3,7 @@ import { types } from 'micromark-util-symbol';
 import { splice } from 'micromark-util-chunked';
 
 import { tokenTypes } from './types.js';
-import { formatEvents } from './utils.js';
-import assert from 'assert';
+import { assert, formatEvents } from './utils.js';
 import Debug from 'debug';
 
 const debug = Debug('micromark-extension-definition-list:defTermFlowToken');

--- a/dev/lib/syntax.ts
+++ b/dev/lib/syntax.ts
@@ -14,10 +14,9 @@ import { factorySpace } from 'micromark-factory-space';
 import { markdownSpace } from 'micromark-util-character';
 import { blankLine } from 'micromark-core-commonmark';
 import { tokenTypes } from './types.js';
-import { formatEvents, formatEvent, code2Str } from './utils.js';
+import { assert, formatEvents, formatEvent, code2Str } from './utils.js';
 import { analyzeDefTermFlow, subtokenizeDefTerm } from './defTermFlowToken.js';
 import { splice } from 'micromark-util-chunked';
-import assert from 'assert';
 import Debug from 'debug';
 
 const debug = Debug('micromark-extension-definition-list:syntax');

--- a/dev/lib/utils.ts
+++ b/dev/lib/utils.ts
@@ -41,3 +41,9 @@ export function code2Str(code: Code): string {
     return '0x' + code.toString(16);
   }
 }
+
+export function assert(condition: unknown, message?: string): asserts condition {
+  if (!condition) {
+    throw new Error(message || 'Assertion failed');
+  }
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "default": "./index.js"
   },
   "dependencies": {
-    "assert": "^2.0.0",
     "micromark-core-commonmark": "^2.0.0",
     "micromark-factory-space": "^2.0.0",
     "micromark-util-character": "^2.0.1",
@@ -43,7 +42,6 @@
   },
   "devDependencies": {
     "@eslint/js": "9.17.0",
-    "@types/assert": "1.5.11",
     "@types/debug": "4.1.12",
     "@types/node": "22.10.10",
     "debug": "4.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      assert:
-        specifier: ^2.0.0
-        version: 2.1.0
       micromark-core-commonmark:
         specifier: ^2.0.0
         version: 2.0.0
@@ -36,9 +33,6 @@ importers:
       '@eslint/js':
         specifier: 9.17.0
         version: 9.17.0
-      '@types/assert':
-        specifier: 1.5.11
-        version: 1.5.11
       '@types/debug':
         specifier: 4.1.12
         version: 4.1.12
@@ -487,9 +481,6 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
-  '@types/assert@1.5.11':
-    resolution: {integrity: sha512-FjS1mxq2dlGr9N4z72/DO+XmyRS3ZZIoVn998MEopAN/OmyN28F4yumRL5pOw2z+hbFLuWGYuF2rrw5p11xM5A==}
-
   '@types/babel__core@7.20.2':
     resolution: {integrity: sha512-pNpr1T1xLUc2l3xJKuPtsEky3ybxN3m4fJkknfIpTCTfIZCDW57oAg+EfCgIIp2rvCe0Wn++/FfodDS4YXxBwA==}
 
@@ -668,9 +659,6 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
-
-  assert@2.1.0:
-    resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1228,19 +1216,12 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
-  inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
   internal-slot@1.0.5:
     resolution: {integrity: sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==}
     engines: {node: '>= 0.4'}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
-    engines: {node: '>= 0.4'}
-
-  is-arguments@1.1.1:
-    resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
     engines: {node: '>= 0.4'}
 
   is-array-buffer@3.0.2:
@@ -1317,10 +1298,6 @@ packages:
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
-    engines: {node: '>= 0.4'}
-
-  is-nan@1.3.2:
-    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
     engines: {node: '>= 0.4'}
 
   is-negative-zero@2.0.2:
@@ -1615,10 +1592,6 @@ packages:
 
   object-inspect@1.13.3:
     resolution: {integrity: sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==}
-    engines: {node: '>= 0.4'}
-
-  object-is@1.1.5:
-    resolution: {integrity: sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==}
     engines: {node: '>= 0.4'}
 
   object-keys@1.1.1:
@@ -2022,9 +1995,6 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  util@0.12.5:
-    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -2473,8 +2443,6 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
-  '@types/assert@1.5.11': {}
-
   '@types/babel__core@7.20.2':
     dependencies:
       '@babel/parser': 7.23.0
@@ -2723,14 +2691,6 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.2.7
       is-array-buffer: 3.0.5
-
-  assert@2.1.0:
-    dependencies:
-      call-bind: 1.0.2
-      is-nan: 1.3.2
-      object-is: 1.1.5
-      object.assign: 4.1.4
-      util: 0.12.5
 
   assertion-error@2.0.1: {}
 
@@ -3456,8 +3416,6 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  inherits@2.0.4: {}
-
   internal-slot@1.0.5:
     dependencies:
       get-intrinsic: 1.2.1
@@ -3469,11 +3427,6 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
-
-  is-arguments@1.1.1:
-    dependencies:
-      call-bind: 1.0.2
-      has-tostringtag: 1.0.0
 
   is-array-buffer@3.0.2:
     dependencies:
@@ -3558,11 +3511,6 @@ snapshots:
       is-extglob: 2.1.1
 
   is-map@2.0.3: {}
-
-  is-nan@1.3.2:
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.1
 
   is-negative-zero@2.0.2: {}
 
@@ -3942,11 +3890,6 @@ snapshots:
   object-inspect@1.12.3: {}
 
   object-inspect@1.13.3: {}
-
-  object-is@1.1.5:
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.1
 
   object-keys@1.1.1: {}
 
@@ -4440,14 +4383,6 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.0
-
-  util@0.12.5:
-    dependencies:
-      inherits: 2.0.4
-      is-arguments: 1.1.1
-      is-generator-function: 1.0.10
-      is-typed-array: 1.1.12
-      which-typed-array: 1.1.11
 
   vite-node@2.1.9(@types/node@22.10.10):
     dependencies:


### PR DESCRIPTION
Replaces the `assert` (browserify) dependency with a lightweight internal `assert` function to avoid the need for `process.env` polyfills in modern bundlers like Webpack 5 and Vite. This reduces bundle size and improves compatibility in frontend environments.

Fixes: https://github.com/wataru-chocola/micromark-extension-definition-list/issues/213